### PR TITLE
CircularJSON and strip-html-tags support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
 'use strict';
 
 const _ = require('lodash');
+const circularJSON = require('circular-json');
+const htmlToText = require('html-to-text');
 
 module.exports = function( options ) {
 
     let outputPath      = options.outputPath || null,           // Specify a path (string) to put the json files eg. /api
         createIndexes   = options.createIndexes || false,       // Specify whether or not to create indexes of the accumulated files
         indexPaths      = options.indexPaths || false,          // Specify paths to source folders with content to index
-        onlyOutputIndex = options.onlyOutputIndex || false;     // Specify if whether or not to only output the index file for each indexPath
+        onlyOutputIndex = options.onlyOutputIndex || false,    // Specify if whether or not to only output the index file for each indexPath
+        stripHTML       = options.stripHTML || false;            // Strip html tags from contents
 
     return function( files, metalsmith, done ) {
 
@@ -15,7 +18,11 @@ module.exports = function( options ) {
 
             let data            = _.omit(file, ['mode', 'stat', '_vinyl', 'stats']);
             data.contents       = file.contents.toString();
-            data.contents       = new Buffer( JSON.stringify( data ), 'utf8' );
+            
+            if (stripHTML)
+                data.contents = stripHTMLContents(data.contents);
+            
+            data.contents       = new Buffer( circularJSON.stringify( data ), 'utf8' );
 
             let filepath        = key.replace('.html', '.json');
             files[filepath]     = data;
@@ -68,4 +75,14 @@ module.exports = function( options ) {
 
     }
 
+}
+
+
+function stripHTMLContents(contents){
+    return htmlToText.fromString(contents, {
+        tables: true,
+        baseElement: 'article#main',
+        ignoreImage: true,
+        ignoreHref: true
+    });
 }

--- a/index.js
+++ b/index.js
@@ -6,11 +6,17 @@ const htmlToText = require('html-to-text');
 
 module.exports = function( options ) {
 
-    let outputPath      = options.outputPath || null,           // Specify a path (string) to put the json files eg. /api
-        createIndexes   = options.createIndexes || false,       // Specify whether or not to create indexes of the accumulated files
-        indexPaths      = options.indexPaths || false,          // Specify paths to source folders with content to index
-        onlyOutputIndex = options.onlyOutputIndex || false,    // Specify if whether or not to only output the index file for each indexPath
-        stripHTML       = options.stripHTML || false;            // Strip html tags from contents
+    let outputPath           = options.outputPath || null,              // Specify a path (string) to put the json files eg. /api
+        createIndexes        = options.createIndexes || false,          // Specify whether or not to create indexes of the accumulated files
+        indexPaths           = options.indexPaths || false,             // Specify paths to source folders with content to index
+        onlyOutputIndex      = options.onlyOutputIndex || false,        // Specify if whether or not to only output the index file for each indexPath
+        stripHTML            = options.stripHTML || false,              // Specify whether or not to strip html tags from contents
+        stripHTMLOptions     = options.stripHTMLOptions || {
+            tables: true,
+            baseElement: 'body',
+            ignoreImage: true,
+            ignoreHref: true
+        }                                                               // Specify options for html-to-text
 
     return function( files, metalsmith, done ) {
 
@@ -18,9 +24,8 @@ module.exports = function( options ) {
 
             let data            = _.omit(file, ['mode', 'stat', '_vinyl', 'stats']);
             data.contents       = file.contents.toString();
-            
             if (stripHTML)
-                data.contents = stripHTMLContents(data.contents);
+                data.contents = stripHTMLContents(data.contents, stripHTMLOptions);
             
             data.contents       = new Buffer( circularJSON.stringify( data ), 'utf8' );
 
@@ -78,11 +83,6 @@ module.exports = function( options ) {
 }
 
 
-function stripHTMLContents(contents){
-    return htmlToText.fromString(contents, {
-        tables: true,
-        baseElement: 'article#main',
-        ignoreImage: true,
-        ignoreHref: true
-    });
+function stripHTMLContents(contents, stripHTMLOptions){
+    return htmlToText.fromString(contents, stripHTMLOptions);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,181 @@
+{
+  "name": "metalsmith-to-json",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "circular-json": {
+      "version": "0.4.0",
+      "resolved": "https://npm.bentley.com/npm/npm/circular-json/-/circular-json-0.4.0.tgz",
+      "integrity": "sha1-xEjqmYt/4x7PRy7CnGtgji4qYv0="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://npm.bentley.com/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://npm.bentley.com/npm/npm/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://npm.bentley.com/npm/npm/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://npm.bentley.com/npm/npm/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://npm.bentley.com/npm/npm/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.6.2",
+      "resolved": "https://npm.bentley.com/npm/npm/domutils/-/domutils-1.6.2.tgz",
+      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://npm.bentley.com/npm/npm/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://npm.bentley.com/npm/npm/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "html-to-text": {
+      "version": "3.3.0",
+      "resolved": "https://npm.bentley.com/npm/npm/html-to-text/-/html-to-text-3.3.0.tgz",
+      "integrity": "sha1-aptjxpm4hbt7qEsURr/mh2u/z7c=",
+      "requires": {
+        "he": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "optimist": "0.6.1",
+        "underscore": "1.8.3",
+        "underscore.string": "3.3.4"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://npm.bentley.com/npm/npm/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.6.2",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://npm.bentley.com/npm/npm/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://npm.bentley.com/npm/npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://npm.bentley.com/npm/npm/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://npm.bentley.com/npm/npm/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://npm.bentley.com/npm/npm/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://npm.bentley.com/npm/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://npm.bentley.com/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://npm.bentley.com/npm/npm/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://npm.bentley.com/npm/npm/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://npm.bentley.com/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://npm.bentley.com/npm/npm/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://npm.bentley.com/npm/npm/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "requires": {
+        "sprintf-js": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://npm.bentley.com/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://npm.bentley.com/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-to-json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin to create json files from metalsmith.",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,8 @@
     "url": "https://github.com/hellotoby/metalsmith-to-json/issues"
   },
   "dependencies": {
+    "circular-json": "^0.4.0",
+    "html-to-text": "^3.3.0",
     "lodash": "^4.14.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -48,3 +48,13 @@ Metalsmith to json takes four options.
 2. createIndexes (boolean) : A boolean to tell metalsmith to json whether or not you'd like to generate indexes.
 3. indexPaths (array) : An array of paths for metalsmith to json to generate indexes from.
 4. onlyOutputIndex (boolean) : A boolean to tell metalsmith to only output the index file for each specified indexPath.
+5. stripHTML (boolean) : A boolean to tell metalsmith-to-json to strip html tags
+6. stripHTMLOptions (object) : Options from [html-to-text](https://github.com/werk85/node-html-to-text) - defaults: 
+```js
+{
+    tables: true,
+    baseElement: 'body',
+    ignoreImage: true,
+    ignoreHref: true
+}
+```


### PR DESCRIPTION
This PR replaces `JSON.stringify` with `CircularJSON.stringify` to prevent circular JSON errors and adds html-to-text as an option to strip html tags when parsing a file's contents.