### PR TITLE
chore: version-bump to allow access to minimist security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-to-json",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A plugin to create json files from metalsmith.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Consuming the `metalsmith-to-json` library does not benefit from the last round of dependency-related security fixes as the version hasn't advanced.  The [NPM registry still sees the most recent version](https://www.npmjs.com/package/metalsmith-to-json?activeTab=code) as being `1.0.2` which is 4 years old.  Version should be bumped, and the updated version to be published, to allow package registries to offer security fixes